### PR TITLE
Modify Soak Tests for ADOT Ruby

### DIFF
--- a/.github/docker-performance-tests/docker-compose.yml
+++ b/.github/docker-performance-tests/docker-compose.yml
@@ -22,7 +22,7 @@ services:
         source: /proc
         target: /proc
     ports:
-      - '4317:4317'
+      - '4318:4318'
     user: "${UID}:${GID}"
 
   app:
@@ -37,7 +37,7 @@ services:
       - AWS_DEFAULT_REGION
       - SAMPLE_APP_LOG_LEVEL=ERROR
       - OTEL_RESOURCE_ATTRIBUTES=service.name=aws-otel-integ-test
-      - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel:4317
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel:4318
     ports:
       - '${LISTEN_ADDRESS_PORT}:${LISTEN_ADDRESS_PORT}'
 

--- a/.github/docker-performance-tests/otel-collector/collector-config.yml
+++ b/.github/docker-performance-tests/otel-collector/collector-config.yml
@@ -1,8 +1,7 @@
 receivers:
   otlp:
     protocols:
-      grpc:
-        endpoint: 0.0.0.0:4317
+      http:
   hostmetrics:
     collection_interval: ${HOSTMETRICS_INTERVAL_SECS}s
     scrapers:
@@ -74,7 +73,8 @@ service:
     metrics:
       receivers:
         - hostmetrics
-        - otlp
+        # Metrics not yet available
+        # - otlp
       processors:
         - filter
         - metricstransform

--- a/.github/workflows/soak-testing.yml
+++ b/.github/workflows/soak-testing.yml
@@ -18,11 +18,11 @@ on:
     - cron: '0 15 * * *'
 env:
   # NOTE: The configuration of `APP_PROCESS_EXECUTABLE_NAME` is repo dependent
-  APP_PROCESS_EXECUTABLE_NAME: EXAMPLE_OF_SOMETHING
+  APP_PROCESS_EXECUTABLE_NAME: ruby
   AWS_DEFAULT_REGION: us-east-1
   DEFAULT_TEST_DURATION_MINUTES: 300
   HOSTMETRICS_INTERVAL_SECS: 600
-  CPU_LOAD_THRESHOLD: 50
+  CPU_LOAD_THRESHOLD: 30
   TOTAL_MEMORY_THRESHOLD: 1073741824 # 1 GiB
   MAX_BENCHMARKS_TO_KEEP: 100
   LISTEN_ADDRESS_PORT: 8080
@@ -43,11 +43,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        app-platform: [ rails ]
+        app-platform: [ ruby-on-rails ]
         instrumentation-type: [ manual ]
     env:
       # NOTE: The configuration of `APP_PATH` is repo dependent
-      APP_PATH: sample-apps
+      APP_PATH: sample-apps/${{ matrix.instrumentation-type}}-instrumentation/${{ matrix.app-platform }}
       LOGS_NAMESPACE: ${{ github.repository }}/soak-tests-${{ matrix.app-platform }}-${{ matrix.instrumentation-type }}
     steps:
     # MARK: - GitHub Workflow Event Type Specific Values
@@ -76,7 +76,7 @@ jobs:
         if: ${{ matrix.instrumentation-type == 'manual' }}
         run: |
           echo 'APP_PROCESS_COMMAND_LINE_DIMENSION_VALUE<<EOF' >> $GITHUB_ENV
-          echo 'EXAMPLE_OF_SOMETHING' | tee --append $GITHUB_ENV;
+          echo 'puma 5.5.2 (tcp://0.0.0.0:${{ env.LISTEN_ADDRESS_PORT }}) [app]' | tee --append $GITHUB_ENV;
           echo 'EOF' >> $GITHUB_ENV
 
     # MARK: - Uniquely identify this Sample App environment


### PR DESCRIPTION
## Description

Just like we have done in the past for the other languages, we make a PR first with only the changes we _need_ to modify the Soak Tests.

We decided these thresholds based on these results from [a run on my demo testing repo](https://github.com/NathanielRN/aws-otel-ruby-tracing-demo/actions/runs/1794007088):

CPU Load:

<img width="1139" alt="image" src="https://user-images.githubusercontent.com/23139455/152881195-db461682-1f55-4798-b59d-2d300da70cd9.png">

30 should allow us to be 3% under the threshold. Because there are no spikes we should feel okay leaving this margin.

Memory Usage:

<img width="1153" alt="image" src="https://user-images.githubusercontent.com/23139455/152881450-aea42ee6-6141-42ab-9c55-b4490f2de533.png">

1 GB should allow us to be 100 MB below the limit. The growth seems stable and not fluctuating so we should confident with this value.